### PR TITLE
KAGの色コードを利用できるようにextensionを作成

### DIFF
--- a/lib/extensions/color_code.dart
+++ b/lib/extensions/color_code.dart
@@ -1,0 +1,19 @@
+import 'package:flutter/material.dart';
+
+const String mainBackGroundColor = "#0E0D66";
+const String subBackGroundColor = "#459BE6";
+const String accentBackGroundColor = "#EA3368";
+const String foregroundColor = "#FFFFFF";
+
+class HexColor extends Color {
+  static int _getColorFromHex(String hexColor) {
+    // 引数を全部大文字に変換して、#を取り除く
+    hexColor = hexColor.toUpperCase().replaceAll("#", "");
+    if (hexColor.length == 6) {
+      hexColor = "FF" + hexColor;
+    }
+    return int.parse(hexColor, radix: 16);
+  }
+
+  HexColor(final String hexColor) : super(_getColorFromHex(hexColor));
+}

--- a/lib/view/home_screen.dart
+++ b/lib/view/home_screen.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:kagb_template/extensions/color_code.dart';
 import 'package:kagb_template/model/todo.dart';
 import 'package:kagb_template/provider/todos.dart';
 import 'package:kagb_template/view/components/todo_card.dart';
@@ -16,7 +17,8 @@ class HomeScreen extends ConsumerWidget {
       child: Scaffold(
         appBar: AppBar(
           title: const Text('Todo App'),
-          backgroundColor: Colors.blue,
+          backgroundColor: HexColor(mainBackGroundColor),
+          foregroundColor: HexColor(foregroundColor),
         ),
         body: Padding(
           padding: const EdgeInsets.all(8.0),
@@ -59,6 +61,8 @@ class HomeScreen extends ConsumerWidget {
         floatingActionButton: FloatingActionButton(
           onPressed: () => print("押された"),
           child: const Icon(Icons.add),
+          backgroundColor: HexColor(mainBackGroundColor),
+          foregroundColor: HexColor(foregroundColor),
         ),
       ),
     );


### PR DESCRIPTION
# Ticket


# やった事

- アプリのボタンや、文字などWidgetでよく利用するKAGのテーマカラーを簡単に利用できるようにした

## なぜやるのか

- 毎回色コードを持ってくるのは面倒だから

# 動作確認


# Refs (レビューにあたって参考にすべき情報）(Optional)

- <img src="画像のURL" width="280px">
